### PR TITLE
#176 사용자 이해를 돕기 위한 메인 페이지 문구 추가하기

### DIFF
--- a/src/frontend/src/views/signin/SignIn.vue
+++ b/src/frontend/src/views/signin/SignIn.vue
@@ -3,7 +3,7 @@
     <v-layout column align-center fill-height class="background">
       <v-flex class="ma-16 pt-16">
         <p id="title">새벽</p>
-        <p id="description">감정 공유 비밀 다이어리</p>
+        <p id="description">함께 쓰는 감정 비밀 다이어리</p>
       </v-flex>
       <v-flex>
         <a href="/oauth2/authorization/naver">

--- a/src/frontend/src/views/signin/SignIn.vue
+++ b/src/frontend/src/views/signin/SignIn.vue
@@ -2,7 +2,8 @@
   <v-app>
     <v-layout column align-center fill-height class="background">
       <v-flex class="ma-16 pt-16">
-        <p>새벽</p>
+        <p id="title">새벽</p>
+        <p id="description">감정 공유 비밀 다이어리</p>
       </v-flex>
       <v-flex>
         <a href="/oauth2/authorization/naver">
@@ -26,8 +27,12 @@ export default {};
   background-position: center center;
   background-size: cover;
 }
-p {
+#title {
   font-size: 40px;
   color: white;
+  text-align: center;
+}
+#description {
+  text-align: center;
 }
 </style>


### PR DESCRIPTION
첫 페이지의 타이틀 아래에 한 줄 요약 설명 추가했습니다! 😀 

초반 기획 회의에서 서비스 한 줄 요약했던 문구인 "익명 감정 공유 다이어리"에서 딱딱한 부분만 조금 풀어보았어요🙂
폰트 색상은 둘 다 흰색으로 하니까 시선이 너무 분산되더라구요~
그래서 요약 문구는 디폴트인 검정색을 쓰고 타이틀은 집중되도록 흰 색으로 유지했습니다!

resolves: #176 

![image](https://user-images.githubusercontent.com/49009406/92766321-0ffa5580-f3d1-11ea-9a12-55a6856a1cfb.png)

