### PR TITLE
#201 피드의 글을 불러올 때마다 튜토리얼 화면이 나오는 버그 수정하기

### DIFF
--- a/src/frontend/src/components/Tutorial.vue
+++ b/src/frontend/src/components/Tutorial.vue
@@ -56,8 +56,8 @@ export default {
   },
   methods: {
     closeTutorial() {
+      this.$emit('closeTutorial');
       localStorage.setItem('tutorial_check', 'yes');
-      this.dialog = false;
     }
   }
 };

--- a/src/frontend/src/views/feed/Feed.vue
+++ b/src/frontend/src/views/feed/Feed.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <Tutorial :dialog="this.tutorialDialog"></Tutorial>
+    <Tutorial
+      :dialog="this.tutorialDialog"
+      @closeTutorial="closeTutorial"
+    ></Tutorial>
     <div class="mt-4 overflow-y-auto">
       <cards :articles="articles" />
     </div>
@@ -106,6 +109,9 @@ export default {
           console.error(error);
         }
       }, 500);
+    },
+    closeTutorial() {
+      this.tutorialDialog = false;
     }
   },
   watch: {


### PR DESCRIPTION
resolves: #201 

Feed 화면을 불러올 시 created()에서 localStorage에 담긴 check 값을 검사하여 
Tutorial 화면 띄우기 값(tutorialDialog)을 true 혹은 false로 바꾸는데요,
하단에 새로 피드를 불러올 경우에는 created()를 타지 않다 보니 계속 Tutorial 화면이 뜨는 것으로 추측되네요..!
그래서 Tutorial 화면의 '시작해볼게요' 버튼 클릭 이벤트에 emit을 넣고
Feed에서 emit을 받아 Tutorial 화면 띄우기 값(:dialog)을 false로 바꾸는 방식을 적용했습니다!!

제가 몇 번 확인했을 때는 문제없이 되었는데, 여러분들께서도 확인 한 번씩만 부탁드립니다 🙇🏻‍♀️