### PR TITLE
#228 정적 자원에 캐싱 적용하기

### DIFF
--- a/src/main/java/com/saebyeok/saebyeok/config/WebMvcConfig.java
+++ b/src/main/java/com/saebyeok/saebyeok/config/WebMvcConfig.java
@@ -2,12 +2,18 @@ package com.saebyeok.saebyeok.config;
 
 import com.saebyeok.saebyeok.controller.resolver.LoginMemberArgumentResolver;
 import com.saebyeok.saebyeok.interceptor.LogInterceptor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import javax.servlet.Filter;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
@@ -30,5 +36,17 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/**")
+                .addResourceLocations("classpath:/static/")
+                .setCacheControl(CacheControl.maxAge(365, TimeUnit.DAYS));
+    }
+
+    @Bean
+    public Filter shallowEtagHeaderFilter() {
+        return new ShallowEtagHeaderFilter();
     }
 }


### PR DESCRIPTION
Resolved #228 

작업량 실화입니다 ㅋㅋㅋㅋㅋㅋㅋㅋ 하....🤦🏻‍♀️
혹시 정적 자원 캐싱을 더 보강 혹은 수정해주실 분 있다면 적극 환영입니다 🤩
이 결과가 나온 과정에 대해서는 [이슈](https://github.com/woowacourse-teams/2020-saebyeok/issues/228)에서 볼 수 있어요! 눈물난다!😂

여기 pr에는 결론 캡처샷만 남겨두겠슴다~

**우선 현재 새벽.net에는 별도로 적용된 캐싱 정책이 없네요~** (ServiceWorker 덕분에 대부분의 리소스가 자동 캐싱되고 있기는 허지만요..^^)
<img width="1434" alt="스크린샷 2020-10-10 오후 8 55 28" src="https://user-images.githubusercontent.com/55046234/95654559-b7d38200-0b3b-11eb-84fe-a6c2d3d499e0.png">

**캐시가 없는 상태에서 feed 화면에 처음 들어갔을 때입니다.**
<img width="1440" alt="스크린샷 2020-10-10 오후 8 44 22" src="https://user-images.githubusercontent.com/55046234/95654341-6080e200-0b3a-11eb-8075-a56a9b11b8bd.png">

**그리고 다시 접속하면!**
<img width="1438" alt="스크린샷 2020-10-10 오후 8 44 50" src="https://user-images.githubusercontent.com/55046234/95654364-7b535680-0b3a-11eb-91ed-5f87f8ad53ba.png">